### PR TITLE
Extend cluster-autoscaler 1.17 to be compatible with Rok

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -133,6 +133,8 @@ type AutoscalingOptions struct {
 	MaxBulkSoftTaintCount int
 	// MaxBulkSoftTaintTime sets the maximum duration of single run of PreferNoSchedule tainting.
 	MaxBulkSoftTaintTime time.Duration
+	// MaxPodEvictionTime set the maximum duration ihe CA tries to evict a pod before giving up.
+	MaxPodEvictionTime time.Duration
 	// Filtering out schedulable pods before CA scale up by trying to pack the schedulable pods on free capacity on existing nodes.
 	// Setting it to false employs a more lenient filtering approach that does not try to pack the pods on the nodes.
 	// Pods with nominatedNodeName set are always filtered out.

--- a/cluster-autoscaler/core/scale_down.go
+++ b/cluster-autoscaler/core/scale_down.go
@@ -64,8 +64,6 @@ const (
 	MaxKubernetesEmptyNodeDeletionTime = 3 * time.Minute
 	// MaxCloudProviderNodeDeletionTime is the maximum time needed by cloud provider to delete a node.
 	MaxCloudProviderNodeDeletionTime = 5 * time.Minute
-	// MaxPodEvictionTime is the maximum time CA tries to evict a pod before giving up.
-	MaxPodEvictionTime = 2 * time.Minute
 	// EvictionRetryTime is the time after CA retries failed pod eviction.
 	EvictionRetryTime = 10 * time.Second
 	// PodEvictionHeadroom is the extra time we wait to catch situations when the pod is ignoring SIGTERM and
@@ -1024,7 +1022,7 @@ func (sd *ScaleDown) deleteNode(node *apiv1.Node, pods []*apiv1.Pod,
 	sd.context.Recorder.Eventf(node, apiv1.EventTypeNormal, "ScaleDown", "marked the node as toBeDeleted/unschedulable")
 
 	// attempt drain
-	evictionResults, err := drainNode(node, pods, sd.context.ClientSet, sd.context.Recorder, sd.context.MaxGracefulTerminationSec, MaxPodEvictionTime, EvictionRetryTime, PodEvictionHeadroom)
+	evictionResults, err := drainNode(node, pods, sd.context.ClientSet, sd.context.Recorder, sd.context.AutoscalingOptions.MaxGracefulTerminationSec, sd.context.AutoscalingOptions.MaxPodEvictionTime, EvictionRetryTime, PodEvictionHeadroom)
 	if err != nil {
 		return status.NodeDeleteResult{ResultType: status.NodeDeleteErrorFailedToEvictPods, Err: err, PodEvictionResults: evictionResults}
 	}

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -132,6 +132,7 @@ var (
 	okTotalUnreadyCount        = flag.Int("ok-total-unready-count", 3, "Number of allowed unready nodes, irrespective of max-total-unready-percentage")
 	scaleUpFromZero            = flag.Bool("scale-up-from-zero", true, "Should CA scale up when there 0 ready nodes.")
 	maxNodeProvisionTime       = flag.Duration("max-node-provision-time", 15*time.Minute, "Maximum time CA waits for node to be provisioned")
+	maxPodEvictionTime         = flag.Duration("max-pod-eviction-time", 2*time.Minute, "Maximum time CA tries to evict a pod before giving up")
 	nodeGroupsFlag             = multiStringFlag(
 		"nodes",
 		"sets min,max size and other configuration data for a node group in a format accepted by cloud provider. Can be used multiple times. Format: <min>:<max>:<other...>")
@@ -208,6 +209,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		MaxEmptyBulkDelete:                  *maxEmptyBulkDeleteFlag,
 		MaxGracefulTerminationSec:           *maxGracefulTerminationFlag,
 		MaxNodeProvisionTime:                *maxNodeProvisionTime,
+		MaxPodEvictionTime:                  *maxPodEvictionTime,
 		MaxNodesTotal:                       *maxNodesTotal,
 		MaxCoresTotal:                       maxCoresTotal,
 		MinCoresTotal:                       minCoresTotal,

--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -33,6 +33,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 
@@ -275,6 +276,13 @@ func findPlaceFor(removedNode string, pods []*apiv1.Pod, nodes []*apiv1.Node, no
 		targetNode := ""
 		predicateMeta := predicateChecker.GetPredicateMetadata(pod, newNodeInfos)
 		loggingQuota.Reset()
+
+		// Skip rok-csi-guard
+		csiGuardSelector, _ := labels.Parse("app=rok-csi-guard")
+		if csiGuardSelector.Matches(labels.Set(pod.Labels)) {
+			klog.V(2).Infof("Skipping findPlceFor for %s pod", pod.Name)
+			continue
+		}
 
 		klog.V(5).Infof("Looking for place for %s/%s", pod.Namespace, pod.Name)
 

--- a/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/controller/volume/scheduling/scheduler_binder.go
+++ b/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/controller/volume/scheduling/scheduler_binder.go
@@ -697,6 +697,12 @@ func (b *volumeBinder) checkBoundClaims(claims []*v1.PersistentVolumeClaim, node
 			return false, err
 		}
 
+		storageClassName := pv.Spec.StorageClassName
+		if storageClassName == "rok" {
+			klog.V(2).Infof("PersistentVolume %q bound with Pod %s is of Rok Storage Class, skipping CheckNodeAffinity()", pvName, podName)
+			return true, nil
+		}
+
 		err = volumeutil.CheckNodeAffinity(pv, node.Labels)
 		if err != nil {
 			klog.V(4).Infof("PersistentVolume %q, Node %q mismatch for Pod %q: %v", pvName, node.Name, podName, err)


### PR DESCRIPTION
This PR extends the cluster autoscaler to be compatible with Rok. Specifically, it:

- Extends `checkPdbs()` to skip the rok-csi-guard PDBs.
- Extends `checkBoundClaims()` to not check bound claims for `rok` Storage Class. 
- Extends `findForPlace()` call to skip rok-csi-guards.

Refs arrikto/rok#4238